### PR TITLE
Support environment-specific stacks

### DIFF
--- a/aws-infrastructure/infrastructure-stacks.py
+++ b/aws-infrastructure/infrastructure-stacks.py
@@ -229,7 +229,7 @@ class AWSInfrastructureStack(core.Stack):
             namespace="kube-system",
             values={
                 "clusterName": eks_cluster.cluster_name,
-                "awsRegion": os.environ["CDK_DEFAULT_REGION"],
+                "awsRegion": self.region,
                 "awsVpcID": eks_vpc.vpc_id,
                 "rbac": {
                     "create": True,
@@ -284,7 +284,7 @@ class AWSInfrastructureStack(core.Stack):
             values={
                 "provider": "aws",
                 "aws": {
-                    "region": os.environ["CDK_DEFAULT_REGION"]
+                    "region": self.region
                 },
                 "serviceAccount": {
                     "create": False,
@@ -329,7 +329,7 @@ class AWSInfrastructureStack(core.Stack):
             namespace="kube-system",
             values={
                 "env": {
-                    "AWS_REGION": os.environ["CDK_DEFAULT_REGION"]
+                    "AWS_REGION": self.region
                 },
                 "serviceAccount": {
                     "name": "kubernetes-external-secrets",


### PR DESCRIPTION
The existing code always uses current shell's environment settings to pass AWS region value to the stack. It is more generic to use `AWSInfrastructureStack.region` attribute (provided by the base `Stack` class). The `region` property will have a concrete value if provided, or deploy-time value otherwise. See [Environments](https://docs.aws.amazon.com/cdk/latest/guide/environments.html) concept, [Stack](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_core.Stack.html#region) class documentation for `region` property, and [Environment](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_core.Environment.html#region) class documentation for more details about this approach.